### PR TITLE
fix globals: global, process

### DIFF
--- a/src/core/browserfs.ts
+++ b/src/core/browserfs.ts
@@ -13,7 +13,7 @@ import * as BFSUtils from './util';
 import * as Errors from './api_error';
 import setImmediate from '../generic/setImmediate';
 
-if ((<any> process)['initializeTTYs']) {
+if (process && (<any> process)['initializeTTYs']) {
   (<any> process)['initializeTTYs']();
 }
 

--- a/src/core/global.ts
+++ b/src/core/global.ts
@@ -6,9 +6,9 @@
  * @hidden
  * @private
  */
-declare var global: any;
+declare var globalThis: any;
 /**
  * @hidden
  */
-const toExport: any = typeof(window) !== 'undefined' ? window : typeof(self) !== 'undefined' ? self : global;
+const toExport: any = typeof(window) !== 'undefined' ? window : typeof(self) !== 'undefined' ? self : typeof (global) !== "undefined" ? global : globalThis;
 export default toExport;


### PR DESCRIPTION
**PR merged from upstream https://github.com/jvilk/BrowserFS/pull/298 from @pkit**

both globals may not be available in embedded environments

there is no need to call `process` at all if it's not there
there is a standardized `global` object now:
[globalThis](https://github.com/tc39/proposal-global), it should be
used as the last resort